### PR TITLE
Add convert nodes for colors from other values

### DIFF
--- a/Sources/ShaderGraphCoder/Conversions.swift
+++ b/Sources/ShaderGraphCoder/Conversions.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+extension SGValue {
+    convenience init(nodeType: String, in connection: SGValue, out: SGDataType) {
+        self.init(source: .nodeOutput(SGNode(nodeType: nodeType, inputs: [.init(name: "in", connection: connection)], outputs: [.init(dataType: out)])))
+    }
+}
+
+// valid color related conversions:
+// grep -REoh 'ND_\w+' /Applications/Xcode.app/Contents/SystemFrameworks/ShaderGraph.framework/Versions/A/Resources | sort -u | grep convert | grep color
+public extension SGColor {
+    convenience init(_ value: SGVector) {
+        switch value.dataType {
+        case .vector3f: self.init(nodeType: "ND_convert_vector3_color3", in: value, out: .color3f)
+        case .vector3h: self.init(nodeType: "ND_convert_half3_color3", in: value, out: .color3f)
+        case .vector4f: self.init(nodeType: "ND_convert_vector4_color4", in: value, out: .color4f)
+        case .vector4h: self.init(nodeType: "ND_convert_half4_color4", in: value, out: .color4f)
+        default:
+            self.init(source: .error("Unsupported input data types. Expected input value to be vector{3f,3h,4f,4h}", values: [value]))
+        }
+    }
+
+    convenience init(color3From value: SGValue) {
+        switch value.dataType {
+        case .color4f: self.init(nodeType: "ND_convert_color4_color3", in: value, out: .color3f)
+        case .float: self.init(nodeType: "ND_convert_float_color3", in: value, out: .color3f)
+        case .half: self.init(nodeType: "ND_convert_half_color3", in: value, out: .color3f)
+        case .vector3f, .vector3h: self.init(SGVector(source: value.source))
+        default:
+            self.init(source: .error("Unsupported input data types. Expected input value to be {color3f,float,half,vector3f,vector3h}", values: [value]))
+        }
+    }
+
+    convenience init(color4From value: SGValue) {
+        switch value.dataType {
+        case .color3f: self.init(nodeType: "ND_convert_color3_color4", in: value, out: .color4f)
+        case .float: self.init(nodeType: "ND_convert_float_color4", in: value, out: .color4f)
+        case .half: self.init(nodeType: "ND_convert_half_color4", in: value, out: .color4f)
+        case .vector4f, .vector4h: self.init(SGVector(source: value.source))
+        default:
+            self.init(source: .error("Unsupported input data types. Expected input value to be {color3f,float,half,vector4f,vector4h}", values: [value]))
+        }
+    }
+}

--- a/Tests/ShaderGraphCoderTests/ShaderGraphCoderTests.swift
+++ b/Tests/ShaderGraphCoderTests/ShaderGraphCoderTests.swift
@@ -162,4 +162,13 @@ final class ShaderGraphCoderTests: XCTestCase {
         let r = SGValue.vector3f(1, 2, 3).add(.vector3f(4, 5, 6)).divide(.float(2))
         try vectorTest(r)
     }
+
+    func testConvertVector3Color3() throws {
+        try colorTest(SGColor(.vector3f(0.0, 0.5, 1.0)))
+    }
+
+    func testConvertColor3Color4() throws {
+        let color = SGColor(color4From: .color3f(0.0, 0.5, 1.0))
+        try surfaceTest(pbrSurface(), geometryModifier: geometryModifier(color: color))
+    }
 }


### PR DESCRIPTION
I've manually added convert nodes (`ND_convert_X_Y` variants) for color outputs.

Valid conversions for color outputs may be the followings, as of Xcode 16.2.0.

```
grep -REoh 'ND_\w+' /Applications/Xcode1620.app/Contents/SystemFrameworks/ShaderGraph.framework/Versions/A/Resources | sort -u | grep convert | grep -E 'color.$'
ND_convert_color3_color4
ND_convert_color4_color3
ND_convert_float_color3
ND_convert_float_color4
ND_convert_half3_color3
ND_convert_half4_color4
ND_convert_half_color3
ND_convert_half_color4
ND_convert_vector3_color3
ND_convert_vector4_color4
```

example:
position -> convert -> pbrSurface.baseColor

![image](https://github.com/user-attachments/assets/ff414b95-99c6-45ef-8e2c-a89ebd1e818e)
